### PR TITLE
Fix client auth

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/typography": "^0.5.16",
+		"@types/jsonwebtoken": "^9.0.8",
 		"autoprefixer": "^10.4.20",
 		"bits-ui": "^0.22.0",
 		"clsx": "^2.1.1",
@@ -34,6 +35,7 @@
 		"vite": "^6.0.0"
 	},
 	"dependencies": {
+		"jsonwebtoken": "^9.0.2",
 		"svelte-feather-icons": "^4.2.0"
 	}
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"@tailwindcss/typography": "^0.5.16",
-		"@types/jsonwebtoken": "^9.0.8",
 		"autoprefixer": "^10.4.20",
 		"bits-ui": "^0.22.0",
 		"clsx": "^2.1.1",
@@ -35,7 +34,6 @@
 		"vite": "^6.0.0"
 	},
 	"dependencies": {
-		"jsonwebtoken": "^9.0.2",
 		"svelte-feather-icons": "^4.2.0"
 	}
 }

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -7,7 +7,7 @@ import { APP_ENV } from '$env/static/private';
 export const handle: Handle = async ({ event, resolve }) => {
     const jwt = event.cookies.get('jwt');
 
-    const publicRoutes = ['/login', '/signup'];
+    const publicRoutes = ['/login', '/register'];
     const productionRoutes = ['/'];
 
     if (APP_ENV === 'PRODUCTION' && !productionRoutes.includes(event.url.pathname)) {

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -1,1 +1,26 @@
 // hooks server: handles session and authentication cookies
+import type { Handle } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import { verifyToken } from '$lib/server/auth';
+import { APP_ENV } from '$env/static/private';
+
+export const handle: Handle = async ({ event, resolve }) => {
+    const jwt = event.cookies.get('jwt');
+
+    const publicRoutes = ['/login', '/signup'];
+    const productionRoutes = ['/'];
+
+    if (APP_ENV === 'PRODUCTION' && !productionRoutes.includes(event.url.pathname)) {
+        return redirect(302, '/');
+    }
+
+    if (!publicRoutes.includes(event.url.pathname)) {
+        const isValid = jwt && verifyToken(jwt);
+        if (!isValid) {
+            return redirect(302, '/login');
+        }
+    }
+
+    return resolve(event);
+}
+

--- a/frontend/src/hooks.server.ts
+++ b/frontend/src/hooks.server.ts
@@ -15,7 +15,8 @@ export const handle: Handle = async ({ event, resolve }) => {
     }
 
     if (!publicRoutes.includes(event.url.pathname)) {
-        const isValid = jwt && verifyToken(jwt);
+        const isValid = jwt && await verifyToken(jwt);
+        
         if (!isValid) {
             return redirect(302, '/login');
         }

--- a/frontend/src/lib/server/auth.ts
+++ b/frontend/src/lib/server/auth.ts
@@ -1,0 +1,13 @@
+import jwt from 'jsonwebtoken';
+import { JWT_SECRET } from '$env/static/private';
+
+const SECRET_KEY = JWT_SECRET || "";
+
+export function verifyToken(token: string) {
+  try {
+    const decoded = jwt.verify(token, SECRET_KEY);
+    return decoded; // Return the decoded token payload
+  } catch (error) {
+    return null; // Token is invalid
+  }
+}

--- a/frontend/src/lib/server/auth.ts
+++ b/frontend/src/lib/server/auth.ts
@@ -1,13 +1,24 @@
-import jwt from 'jsonwebtoken';
-import { JWT_SECRET } from '$env/static/private';
+import { GO_BACKEND_URL } from '$env/static/private';
 
-const SECRET_KEY = JWT_SECRET || "";
+export async function verifyToken(token: string) {
+    try {
+        const res = await fetch(`${GO_BACKEND_URL}/api/verify`, {
+            method: 'POST',
+            headers: {
+				'Content-Type': 'application/json',
+				'Authorization': `Bearer ${token}`
+			},
+            body: JSON.stringify({}),
+        });
 
-export function verifyToken(token: string) {
-  try {
-    const decoded = jwt.verify(token, SECRET_KEY);
-    return decoded; // Return the decoded token payload
-  } catch (error) {
-    return null; // Token is invalid
-  }
+        if (!res.ok) {
+            throw new Error('Failed to verify token');
+        }
+
+        const response = await res.json();
+        return response.success === "true";
+
+    } catch (error) {
+        return false; // Token is invalid
+    }
 }

--- a/frontend/src/lib/server/auth.ts
+++ b/frontend/src/lib/server/auth.ts
@@ -16,7 +16,7 @@ export async function verifyToken(token: string) {
         }
 
         const response = await res.json();
-        return response.success === "true";
+        return response.valid;
 
     } catch (error) {
         return false; // Token is invalid

--- a/frontend/src/routes/chat/+page.server.ts
+++ b/frontend/src/routes/chat/+page.server.ts
@@ -1,12 +1,1 @@
-import type { PageServerLoad } from './$types';
-import { redirect } from '@sveltejs/kit';
-
-export const load: PageServerLoad = async ({ cookies }) => {
-  const session = cookies.get('session');
-  if (!session) {
-    // No user, redirect to login
-    throw redirect(302, '/login');
-  }
-  // Else proceed, maybe fetch chat data
-  return {};
-};
+// server side route for chat page

--- a/frontend/src/routes/login/+page.server.ts
+++ b/frontend/src/routes/login/+page.server.ts
@@ -27,7 +27,7 @@ export const actions = {
                 const msg = await res.text();
                 
                 // Return an error to the page to display
-                return fail(res.status, { errorMessage: msg });
+                return fail(res.status, { error: msg });
             }
 
             const response = await res.json();
@@ -43,7 +43,7 @@ export const actions = {
             if (response.error == null || response.error === '') {
                 return { success: true };
             } else {
-                return fail(400, { errorMessage: response.error });
+                return fail(400, { error: response.error });
             }
 
         } catch (error) {

--- a/frontend/src/routes/login/+page.server.ts
+++ b/frontend/src/routes/login/+page.server.ts
@@ -31,9 +31,16 @@ export const actions = {
             }
 
             const response = await res.json();
-            cookies.set('session', response.token, { path: '/', maxAge: 60 * 60 * 24 * 30 });
 
-            if (response.error === '') {
+            // Store JWT token in an HTTP-only cookie
+            cookies.set('jwt', response.token, {
+                httpOnly: true, // Prevent client-side access
+                secure: true,   // Only send over HTTPS
+                path: '/',      // Accessible across the entire app
+                maxAge: 60 * 60 * 24 // 1 day
+            });
+
+            if (response.error == null || response.error === '') {
                 return { success: true };
             } else {
                 return fail(400, { errorMessage: response.error });

--- a/frontend/src/routes/login/+page.server.ts
+++ b/frontend/src/routes/login/+page.server.ts
@@ -37,7 +37,8 @@ export const actions = {
                 httpOnly: true, // Prevent client-side access
                 secure: true,   // Only send over HTTPS
                 path: '/',      // Accessible across the entire app
-                maxAge: 60 * 60 * 24 // 1 day
+                maxAge: 60 * 60 * 24, // 1 day
+                sameSite: 'lax'
             });
 
             if (response.error == null || response.error === '') {

--- a/frontend/src/routes/login/+page.server.ts
+++ b/frontend/src/routes/login/+page.server.ts
@@ -38,7 +38,7 @@ export const actions = {
                 secure: true,   // Only send over HTTPS
                 path: '/',      // Accessible across the entire app
                 maxAge: 60 * 60 * 24, // 1 day
-                sameSite: 'lax'
+                sameSite: 'strict'
             });
 
             if (response.error == null || response.error === '') {

--- a/frontend/src/routes/profile/+page.server.ts
+++ b/frontend/src/routes/profile/+page.server.ts
@@ -1,12 +1,1 @@
-import type { PageServerLoad } from './$types';
-import { redirect } from '@sveltejs/kit';
-
-export const load: PageServerLoad = async ({ cookies }) => {
-  const session = cookies.get('session');
-  if (!session) {
-    // No user, redirect to login
-    throw redirect(302, '/login');
-  }
-  // Else proceed, maybe fetch chat data
-  return {};
-};
+// server side route for profile page

--- a/frontend/src/routes/register/+page.server.ts
+++ b/frontend/src/routes/register/+page.server.ts
@@ -1,6 +1,27 @@
-import { fail, redirect } from '@sveltejs/kit';
+import { fail, type Cookies } from '@sveltejs/kit';
 import type { Actions } from './$types';
 import { GO_BACKEND_URL } from '$env/static/private';
+
+const login = async (email: string, password: string, cookies: Cookies) => {
+    const loginRes = await fetch(`${GO_BACKEND_URL}/api/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ "email": email, "password": password }),
+    });
+
+    if (!loginRes.ok) {
+        const msg = await loginRes.text();
+        return fail(loginRes.status, { error: msg });
+    }
+
+    const response = await loginRes.json();
+    cookies.set('jwt', response.token, {
+        httpOnly: true,
+        secure: true,
+        path: '/',
+        maxAge: 60 * 60 * 24
+    });
+}
 
 export const actions = {
     default: async ({ request, cookies }) => {
@@ -18,7 +39,7 @@ export const actions = {
             });
         }
         
-        const res = await fetch(`${GO_BACKEND_URL}/api/register`, {
+        const registerRes = await fetch(`${GO_BACKEND_URL}/api/register`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -26,19 +47,20 @@ export const actions = {
             body: JSON.stringify({ "email": email, "name": name, "password": password }),
         });
 
-        if (!res.ok) {
-            const msg = await res.text();
+        if (!registerRes.ok) {
+            const msg = await registerRes.text();
 
             // Return an error to the page to display
-            return fail(res.status, { errorMessage: msg });
+            return fail(registerRes.status, { error: msg });
         }
 
-        const response = await res.json();
+        const response = await registerRes.json();
 
         if (response.success) {
+            await login(email.toString(), password.toString(), cookies);
             return { success: true };
         } else {
-            return fail(400, { errorMessage: response.error });
+            return fail(400, { error: response.error });
         }
         
     }

--- a/frontend/src/routes/register/+page.server.ts
+++ b/frontend/src/routes/register/+page.server.ts
@@ -20,7 +20,7 @@ const login = async (email: string, password: string, cookies: Cookies) => {
         secure: true,
         path: '/',
         maxAge: 60 * 60 * 24,
-        sameSite: 'lax'
+        sameSite: 'strict'
     });
 }
 

--- a/frontend/src/routes/register/+page.server.ts
+++ b/frontend/src/routes/register/+page.server.ts
@@ -19,7 +19,8 @@ const login = async (email: string, password: string, cookies: Cookies) => {
         httpOnly: true,
         secure: true,
         path: '/',
-        maxAge: 60 * 60 * 24
+        maxAge: 60 * 60 * 24,
+        sameSite: 'lax'
     });
 }
 

--- a/frontend/src/routes/register/+page.svelte
+++ b/frontend/src/routes/register/+page.svelte
@@ -10,8 +10,8 @@
 
     // Check for success or error in the server response
     $: if (form?.success) {
-        toast.success('Registration successful!');
-        goto('/login');
+        toast.success('Welcome aboard! 🎉');
+        goto('/chat');
     }
 
     $: if (form?.error) {


### PR DESCRIPTION
# Description

- Storage of JWT in secured, HTTP-Only cookies.
- Global route restriction utilizing SvelteKit hooks
- Auto login following successful registration


After much research regarding proper and secure client-side storage of JWTs in SSR applications, the safest and most common practice is to store JWTs in secured, HTTP-Only cookies on the server side. Since all current requests to the Go server are made through our SvelteKit proxy server, the token does not need to be exposed to the client and should not be.

### Why this works 
- Security: The JWT token is stored in an HTTP-only cookie, which is inaccessible to client-side JavaScript and protected from XSS attacks. We want to avoid storing the token in localStorage, sessionStorage, or cookies accessible via JavaScript. Proper security flags (SameSite cookies) also mitigate CSRF attacks. 
- Lack of Server-Side localStorage/sessionStorage: Both localStorage and sessionStorage are not available to our SvelteKit proxy server and would require the client sending over the JWT (which it should not have access to in the first place)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)