### PR TITLE
Get me

### DIFF
--- a/backend/authentication/database.go
+++ b/backend/authentication/database.go
@@ -33,48 +33,51 @@ func createUser(ctx context.Context, tx *sql.Tx, email string, passwordHash stri
 //   - fetches a user's email, password hash, name, and alias from the users table with the given user ID in the given transaction
 //   - returns: email, password hash, name, alias, or an error
 //   - assumes: you will close this transaction in the parent function!
-func getUserById(ctx context.Context, tx *sql.Tx, userId string) (string, string, string, string, error) {
+func getUserById(ctx context.Context, tx *sql.Tx, userId string) (string, string, string, string, int, error) {
 	var email, passwordHash, name, alias string
+	var avatarNum int
 	err := tx.QueryRowContext(
 		ctx,
-		"SELECT email, password_hash, name, alias FROM users WHERE id = $1",
+		"SELECT email, password_hash, name, alias, avatar_num FROM users WHERE id = $1",
 		userId,
-	).Scan(&email, &passwordHash, &name, &alias)
+	).Scan(&email, &passwordHash, &name, &alias, &avatarNum)
 	if err != nil {
-		return "", "", "", "", err
+		return "", "", "", "", 0, err
 	}
-	return email, passwordHash, name, alias, nil
+	return email, passwordHash, name, alias, avatarNum, nil
 }
 
 // func(context, current open transaction, email)
 //   - fetches a user's id, password hash, name, and alias from the users table with the given email in the given transaction
 //   - returns: user ID, password hash, name, alias, or an error
 //   - assumes: you will close this transaction in the parent function!
-func getUserByEmail(ctx context.Context, tx *sql.Tx, email string) (string, string, string, string, error) {
+func getUserByEmail(ctx context.Context, tx *sql.Tx, email string) (string, string, string, string, int, error) {
 	var userId, passwordHash, name, alias string
+	var avatarNum int
 	err := tx.QueryRowContext(
 		ctx,
-		"SELECT id, password_hash, name, alias FROM users WHERE email = $1",
+		"SELECT id, password_hash, name, alias, avatar_num FROM users WHERE email = $1",
 		email,
-	).Scan(&userId, &passwordHash, &name, &alias)
+	).Scan(&userId, &passwordHash, &name, &alias, &avatarNum)
 	if err != nil {
-		return "", "", "", "", err
+		return "", "", "", "", 0, err
 	}
-	return userId, passwordHash, name, alias, nil
+	return userId, passwordHash, name, alias, avatarNum, nil
 }
 
 // func(context, current open transaction, user ID, email, password hash, name, alias)
 //   - updates a user's email, password hash, name, and alias in the users table with the given user ID in the given transaction
 //   - returns: the updated user's ID or an error
 //   - assumes: you will close this transaction in the parent function!
-func updateUser(ctx context.Context, tx *sql.Tx, userId string, email string, passwordHash string, name string, alias string) (string, error) {
+func updateUser(ctx context.Context, tx *sql.Tx, userId string, email string, passwordHash string, name string, alias string, avatarNum int) (string, error) {
 	_, err := tx.ExecContext(
 		ctx,
-		`UPDATE users SET email = $1, password_hash = $2, name = $3, alias = $4 WHERE id = $5`,
+		`UPDATE users SET email = $1, password_hash = $2, name = $3, alias = $4, avatar_num = $5 WHERE id = $6`,
 		email,
 		passwordHash,
 		name,
 		alias,
+		avatarNum,
 		userId,
 	)
 	if err != nil {

--- a/backend/authentication/main.go
+++ b/backend/authentication/main.go
@@ -157,6 +157,7 @@ func (s *authServer) connectToDatabase(ctx context.Context, contextDuration time
             password_hash TEXT NOT NULL,
             name VARCHAR(255) NOT NULL,
 			alias VARCHAR(255) NOT NULL,
+			avatar_num INT NOT NULL DEFAULT 1,
             created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
         );

--- a/backend/authentication/rpc.go
+++ b/backend/authentication/rpc.go
@@ -88,7 +88,7 @@ func (s *authServer) Login(ctx context.Context, req *pb.LoginRequest) (*pb.Login
 	}
 	defer tx.Rollback()
 
-	id, encodedHash, name, alias, err := getUserByEmail(ctx, tx, strings.ToLower(req.Email))
+	id, encodedHash, name, alias, avatarNum, err := getUserByEmail(ctx, tx, strings.ToLower(req.Email))
 	if err == sql.ErrNoRows {
 		// Even though the user doesn't exist we want to fake a comparison
 		dummyEncodedHash := fmt.Sprintf(
@@ -135,7 +135,7 @@ func (s *authServer) Login(ctx context.Context, req *pb.LoginRequest) (*pb.Login
 		return nil, err
 	}
 
-	return &pb.LoginResponse{Token: tokenString, UserId: id, Name: name, Alias: alias}, nil
+	return &pb.LoginResponse{Token: tokenString, UserId: id, Name: name, Alias: alias, AvatarNum: int32(avatarNum)}, nil
 }
 
 // rpc(context, register request)
@@ -902,53 +902,69 @@ func (s *authServer) SignCSR(ctx context.Context, req *pb.SignCSRRequest) (*pb.S
 	}, nil
 }
 
-// rpc(context, set alias request)
-//   - takes a user id and an alias, and updates the user's alias in the database
+// rpc(context, set user account settings request)
+//   - takes a user id, name, alias, and avatar number, and updates the user's name, alias, and avatar in the database
 //   - returns an empty response on success, or error on failure
-func (s *authServer) SetAlias(ctx context.Context, req *pb.SetAliasRequest) (*pb.SetAliasResponse, error) {
+func (s *authServer) SetUserAccountSettings(ctx context.Context, req *pb.SetUserAccountSettingsRequest) (*pb.SetUserAccountSettingsResponse, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return &pb.SetAliasResponse{}, err
+		return &pb.SetUserAccountSettingsResponse{}, err
 	}
 	defer tx.Rollback()
 
-	email, passwordHash, name, _, err := getUserById(ctx, tx, req.UserId)
+	email, passwordHash, name, alias, avatarNum, err := getUserById(ctx, tx, req.UserId)
 	if err != nil {
-		return &pb.SetAliasResponse{}, err
+		return &pb.SetUserAccountSettingsResponse{}, err
 	}
 
-	_, err = updateUser(ctx, tx, req.UserId, email, passwordHash, name, req.Alias)
+	// perform updates on the existing values only if the values are not empty strings
+	if (req.Name != "") {
+		name = req.Name
+	}
+	if (req.Alias != "") {
+		alias = req.Alias
+	}
+	if (req.AvatarNum != 0) {
+		avatarNum = int(req.AvatarNum)
+	}
+
+	_, err = updateUser(ctx, tx, req.UserId, email, passwordHash, name, alias, avatarNum)
 	if err != nil {
-		return &pb.SetAliasResponse{}, err
+		return &pb.SetUserAccountSettingsResponse{}, err
 	}
 
 	if err := tx.Commit(); err != nil {
-		return &pb.SetAliasResponse{}, err
+		return &pb.SetUserAccountSettingsResponse{}, err
 	}
 
-	return &pb.SetAliasResponse{}, nil
+	return &pb.SetUserAccountSettingsResponse{}, nil
 }
 
-// rpc(context, get alias request)
+// rpc(context, get user account settings request)
 //   - takes a user id and retrieves the user's alias from the database
 //   - returns the alias string on success, or error on failure
-func (s *authServer) GetAlias(ctx context.Context, req *pb.GetAliasRequest) (*pb.GetAliasResponse, error) {
+func (s *authServer) GetUserAccountSettings(ctx context.Context, req *pb.GetUserAccountSettingsRequest) (*pb.GetUserAccountSettingsResponse, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return &pb.GetAliasResponse{}, err
+		return &pb.GetUserAccountSettingsResponse{}, err
 	}
 	defer tx.Rollback()
 
-	_, _, _, alias, err := getUserById(ctx, tx, req.UserId)
+	email, _, name, alias, avatarNum, err := getUserById(ctx, tx, req.UserId)
 	if err != nil {
-		return &pb.GetAliasResponse{}, err
+		return &pb.GetUserAccountSettingsResponse{}, err
 	}
 
 	if err := tx.Commit(); err != nil {
-		return &pb.GetAliasResponse{}, err
+		return &pb.GetUserAccountSettingsResponse{}, err
 	}
 
-	return &pb.GetAliasResponse{Alias: alias}, nil
+	return &pb.GetUserAccountSettingsResponse{
+		Alias:   alias,
+		Name:    name,
+		Email:   email,
+		AvatarNum: int32(avatarNum),
+	}, nil
 }
 
 // rpc(context, delete account request)

--- a/backend/common/api/authentication.proto
+++ b/backend/common/api/authentication.proto
@@ -13,8 +13,8 @@ service AuthenticationService {
     rpc ForgotPassword(ForgotPasswordRequest) returns (ForgotPasswordResponse);
     rpc ResetPassword(ResetPasswordRequest) returns (ResetPasswordResponse);
     rpc ResendOTP(ResendOTPRequest) returns (ResendOTPResponse);
-    rpc SetAlias(SetAliasRequest) returns (SetAliasResponse);
-    rpc GetAlias(GetAliasRequest) returns (GetAliasResponse);
+    rpc SetUserAccountSettings(SetUserAccountSettingsRequest) returns (SetUserAccountSettingsResponse);
+    rpc GetUserAccountSettings(GetUserAccountSettingsRequest) returns (GetUserAccountSettingsResponse);
     rpc DeleteAccount(DeleteUserRequest) returns (DeleteUserResponse);
 }
 
@@ -28,6 +28,7 @@ message LoginResponse {
     string user_id = 2;
     string name = 3;
     string alias = 4;
+    int32 avatar_num = 5;
 }
 
 message RegisterRequest {
@@ -104,20 +105,25 @@ message ResetPasswordResponse {
     string error = 2;
 }
 
-message SetAliasRequest {
+message SetUserAccountSettingsRequest {
     string user_id = 1;
     string alias = 2;
+    string name = 3;
+    int32 avatar_num = 4;
 }
 
-message SetAliasResponse {
+message SetUserAccountSettingsResponse {
 }
 
-message GetAliasRequest {
+message GetUserAccountSettingsRequest {
     string user_id = 1;
 }
 
-message GetAliasResponse {
+message GetUserAccountSettingsResponse {
     string alias = 1;
+    string name = 2;
+    string email = 3;
+    int32 avatar_num = 4;
 }
 
 message DeleteUserRequest {

--- a/backend/common/api/http.proto
+++ b/backend/common/api/http.proto
@@ -70,7 +70,8 @@ message HttpLoginResponse {
   string user_id = 2;
   string name = 3;
   string alias = 4;
-  string error = 5;
+  int32 avatar_num = 5;
+  string error = 6;
 }
 
 message HttpVerifyResponse {
@@ -88,16 +89,21 @@ message HttpCSRResponse {
   string error = 2;
 }
 
-message HttpSetAliasRequest {
-  string alias = 1;
+message HttpSetMeRequest {
+  string name = 1;
+  string alias = 2;
+  int32 avatar_num = 3;
 }
 
-message HttpSetAliasResponse {}
+message HttpSetMeResponse {}
 
-message HttpGetAliasRequest {}
+message HttpGetMeRequest {}
 
-message HttpGetAliasResponse {
+message HttpGetMeResponse {
   string alias = 1;
+  string name = 2;
+  string email = 3;
+  int32 avatar_num = 4;
 }
 
 message HttpGetIntegrationsRequest {

--- a/backend/gateway/main.go
+++ b/backend/gateway/main.go
@@ -713,6 +713,7 @@ func handleLoginGenerator(clients *ServiceClients) http.HandlerFunc {
 			UserId: res.UserId,
 			Name:   res.Name,
 			Alias:  res.Alias,
+			AvatarNum: res.AvatarNum,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(httpResponse)
@@ -940,11 +941,11 @@ func handleSignCSRGenerator(clients *ServiceClients) http.HandlerFunc {
 	}
 }
 
-func handleSetAliasGenerator(clients *ServiceClients) http.HandlerFunc {
+func handleSetMeGenerator(clients *ServiceClients) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log.Println("Received set alias request")
-		var setAliasRequest pb.HttpSetAliasRequest
-		if err := json.NewDecoder(r.Body).Decode(&setAliasRequest); err != nil {
+		log.Println("Received set me request")
+		var setMeRequest pb.HttpSetMeRequest
+		if err := json.NewDecoder(r.Body).Decode(&setMeRequest); err != nil {
 			http.Error(w, "Bad Request", http.StatusBadRequest)
 			return
 		}
@@ -955,14 +956,16 @@ func handleSetAliasGenerator(clients *ServiceClients) http.HandlerFunc {
 			Token: auth_token,
 		})
 
-		// try to make a set alias request
-		_, err := clients.authClient.SetAlias(r.Context(), &pb.SetAliasRequest{
+		// try to make a set me request
+		_, err := clients.authClient.SetUserAccountSettings(r.Context(), &pb.SetUserAccountSettingsRequest{
 			UserId: verifyRes.UserId,
-			Alias: setAliasRequest.Alias,
+			Alias: setMeRequest.Alias,
+			Name: setMeRequest.Name,
+			AvatarNum: setMeRequest.AvatarNum,
 		})
 
 		if err != nil {
-			http.Error(w, "Failed to set alias", http.StatusInternalServerError)
+			http.Error(w, "Failed to set me", http.StatusInternalServerError)
 			return
 		}
 
@@ -970,9 +973,9 @@ func handleSetAliasGenerator(clients *ServiceClients) http.HandlerFunc {
 	}
 }
 
-func handleGetAliasGenerator(clients *ServiceClients) http.HandlerFunc {
+func handleGetMeGenerator(clients *ServiceClients) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		log.Println("Received get alias request")
+		log.Println("Received get me request")
 
 		auth_header := r.Header.Get("Authorization")
 		auth_token := strings.TrimPrefix(auth_header, "Bearer ")
@@ -980,18 +983,21 @@ func handleGetAliasGenerator(clients *ServiceClients) http.HandlerFunc {
 			Token: auth_token,
 		})
 
-		// try to make a get alias request
-		aliasRes, err := clients.authClient.GetAlias(r.Context(), &pb.GetAliasRequest{
+		// try to make a get me request
+		accountRes, err := clients.authClient.GetUserAccountSettings(r.Context(), &pb.GetUserAccountSettingsRequest{
 			UserId: verifyRes.UserId,
 		})
 
 		if err != nil {
-			http.Error(w, "Failed to get alias", http.StatusInternalServerError)
+			http.Error(w, "Failed to get user account settings", http.StatusInternalServerError)
 			return
 		}
 
-		httpResponse := &pb.HttpGetAliasResponse{
-			Alias: aliasRes.Alias,
+		httpResponse := &pb.HttpGetMeResponse{
+			Alias:       	accountRes.Alias,
+			Name:        	accountRes.Name,
+			Email:       	accountRes.Email,
+			AvatarNum:   	accountRes.AvatarNum,
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(httpResponse)
@@ -1188,8 +1194,8 @@ func main() {
 	mux.HandleFunc("POST /api/login", handleLoginGenerator(serviceClients))
 	mux.HandleFunc("POST /api/verify", handleVerifyGenerator(serviceClients))
 	mux.HandleFunc("POST /api/csr", handleSignCSRGenerator(serviceClients))
-	mux.HandleFunc("POST /api/set_alias", authMiddleware(handleSetAliasGenerator(serviceClients), serviceClients))
-	mux.HandleFunc("GET /api/get_alias", authMiddleware(handleGetAliasGenerator(serviceClients), serviceClients))
+	mux.HandleFunc("POST /api/set_me", authMiddleware(handleSetMeGenerator(serviceClients), serviceClients))
+	mux.HandleFunc("GET /api/get_me", authMiddleware(handleGetMeGenerator(serviceClients), serviceClients))
 	mux.HandleFunc("POST /api/delete_account", authMiddleware(handleDeleteAccountGenerator(serviceClients), serviceClients))
 	mux.HandleFunc("POST /api/connect", authMiddleware(handleConnectIntegrationGenerator(serviceClients), serviceClients))
 	mux.HandleFunc("POST /api/disconnect", authMiddleware(handleDisconnectIntegrationGenerator(serviceClients), serviceClients))


### PR DESCRIPTION
# Description

This PR updates the user account settings handling in the authentication service and its HTTP API. The main changes are:

- **User Model Expansion:** Adds an `avatar_num` field to the user model and updates all related database access methods (`getUserById`, `getUserByEmail`, `updateUser`) to support this new field.
- **API Refactor:** Replaces the `/api/set_alias` and `/api/get_alias` endpoints with `/api/set_me` and `/api/get_me`, expanding their scope to manage and retrieve not just the alias, but also the user's name and avatar number (and, for "get", the email).
- **Handler and gRPC Updates:** Renames handler functions and updates internal gRPC calls to use new methods (`SetUserAccountSettings`, `GetUserAccountSettings`) and updated protobuf messages.
- **Response Structure:** Adjusts HTTP response types to return the expanded user profile data.

**Motivation & Context:**  
The changes enable richer user profile management, supporting additional fields (name, alias, avatar number, email) and clarifying endpoint semantics. This improves user experience and aligns the API with best practices.

**Dependencies:**  
- The database schema must include an `avatar_num` field in the `users` table.
- The authentication service's protobuf definitions and gRPC server must support the new methods/messages.
- Client code and documentation referencing the old endpoints must be updated.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
