### PR TITLE
Password Hash error hot fix

### DIFF
--- a/backend/authentication/database.go
+++ b/backend/authentication/database.go
@@ -34,7 +34,8 @@ func createUser(ctx context.Context, tx *sql.Tx, email string, passwordHash stri
 //   - returns: email, password hash, name, alias, or an error
 //   - assumes: you will close this transaction in the parent function!
 func getUserById(ctx context.Context, tx *sql.Tx, userId string) (string, string, string, string, int, error) {
-	var email, passwordHash, name, alias string
+	var email, name, alias string
+	var passwordHash sql.NullString
 	var avatarNum int
 	err := tx.QueryRowContext(
 		ctx,
@@ -44,7 +45,11 @@ func getUserById(ctx context.Context, tx *sql.Tx, userId string) (string, string
 	if err != nil {
 		return "", "", "", "", 0, err
 	}
-	return email, passwordHash, name, alias, avatarNum, nil
+	actualPasswordHash := ""
+	if passwordHash.Valid {
+		actualPasswordHash = passwordHash.String
+	}
+	return email, actualPasswordHash, name, alias, avatarNum, nil
 }
 
 // func(context, current open transaction, email)
@@ -52,7 +57,8 @@ func getUserById(ctx context.Context, tx *sql.Tx, userId string) (string, string
 //   - returns: user ID, password hash, name, alias, or an error
 //   - assumes: you will close this transaction in the parent function!
 func getUserByEmail(ctx context.Context, tx *sql.Tx, email string) (string, string, string, string, int, error) {
-	var userId, passwordHash, name, alias string
+	var userId, name, alias string
+	var passwordHash sql.NullString
 	var avatarNum int
 	err := tx.QueryRowContext(
 		ctx,
@@ -62,14 +68,20 @@ func getUserByEmail(ctx context.Context, tx *sql.Tx, email string) (string, stri
 	if err != nil {
 		return "", "", "", "", 0, err
 	}
-	return userId, passwordHash, name, alias, avatarNum, nil
+
+	actualPasswordHash := ""
+	if passwordHash.Valid {
+		actualPasswordHash = passwordHash.String
+	}
+
+	return userId, actualPasswordHash, name, alias, avatarNum, nil
 }
 
 // func(context, current open transaction, user ID, email, password hash, name, alias)
 //   - updates a user's email, password hash, name, and alias in the users table with the given user ID in the given transaction
 //   - returns: the updated user's ID or an error
 //   - assumes: you will close this transaction in the parent function!
-func updateUser(ctx context.Context, tx *sql.Tx, userId string, email string, passwordHash string, name string, alias string, avatarNum int) (string, error) {
+func updateUser(ctx context.Context, tx *sql.Tx, userId string, email string, passwordHash sql.NullString, name string, alias string, avatarNum int) (string, error) {
 	_, err := tx.ExecContext(
 		ctx,
 		`UPDATE users SET email = $1, password_hash = $2, name = $3, alias = $4, avatar_num = $5 WHERE id = $6`,

--- a/backend/authentication/rpc.go
+++ b/backend/authentication/rpc.go
@@ -977,7 +977,9 @@ func (s *authServer) SetUserAccountSettings(ctx context.Context, req *pb.SetUser
 		avatarNum = int(req.AvatarNum)
 	}
 
-	_, err = updateUser(ctx, tx, req.UserId, email, passwordHash, name, alias, avatarNum)
+	// Convert passwordHash string to sql.NullString for updateUser
+	passwordHashNull := sql.NullString{String: passwordHash, Valid: passwordHash != ""}
+	_, err = updateUser(ctx, tx, req.UserId, email, passwordHashNull, name, alias, avatarNum)
 	if err != nil {
 		return &pb.SetUserAccountSettingsResponse{}, err
 	}


### PR DESCRIPTION
# Description

This PR addresses a critical bug in the authentication service where attempting to scan a NULL value from the `password_hash` column into a Go `string` caused runtime errors (`sql: Scan error on column index 1, name "password_hash": converting NULL to string is unsupported`). This typically occurred when user records were created without a password hash (e.g., SSO users).

**Summary of changes:**
- Updated [getUserByEmail](cci:1://file:///home/sweetboba/Desktop/indeq/backend/authentication/database.go:54:0-77:1) and [getUserById](cci:1://file:///home/sweetboba/Desktop/indeq/backend/authentication/database.go:31:0-52:1) to scan `password_hash` into a `sql.NullString`, allowing for safe handling of NULL values.
- Updated [updateUser](cci:1://file:///home/sweetboba/Desktop/indeq/backend/authentication/database.go:79:0-98:1) to accept `passwordHash` as a `sql.NullString` parameter, enabling updates that can set the column to NULL.
- Refactored all usages of [updateUser](cci:1://file:///home/sweetboba/Desktop/indeq/backend/authentication/database.go:79:0-98:1) (notably in [SetUserAccountSettings](cci:1://file:///home/sweetboba/Desktop/indeq/backend/authentication/rpc.go:953:0-989:1) in [rpc.go](cci:7://file:///home/sweetboba/Desktop/indeq/backend/authentication/rpc.go:0:0-0:0)) to construct and pass a `sql.NullString` for the password hash argument.
- Ensured consistency and robustness in handling user records with or without password hashes, improving support for SSO-only users and future extensibility.

**Motivation and context:**
- Fixes a runtime bug affecting user login, registration, and settings update flows for users with NULL password hashes.
- Aligns the backend with best practices for handling nullable database fields in Go.
- No new dependencies were introduced.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)